### PR TITLE
Fix wrong config variable name in docs

### DIFF
--- a/doc/miniSnip.txt
+++ b/doc/miniSnip.txt
@@ -102,7 +102,7 @@ Default: '[ substitute(&rtp, ",.*", "", "")."/miniSnip" ]'
 A list of directories to look for snippet files.
 
 For example to share system-wide snippets: >
-    let g:miniSnip_dir = [ '/usr/share/miniSnip', '~/.vim/miniSnip' ]
+    let g:miniSnip_dirs = [ '/usr/share/miniSnip', '~/.vim/miniSnip' ]
 
 -------------------------------------------------------------------------------
                                                              *'g:miniSnip_ext'*


### PR DESCRIPTION
Config variable is g:miniSnip_dirs, example has  g:miniSnip_dir (singular)